### PR TITLE
fixed undefined ordinal suffix on 10th, 20th and 30th day of the month

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1288,7 +1288,7 @@ function ordinalSuffix(n: number): string {
 	// This only works for numbers under 100, which is all we need.
 	const lastDigit = n % 10
 
-	if (n != 11 && n != 12 && n != 13 && lastDigit < 4) {
+	if (n != 11 && n != 12 && n != 13 && lastDigit > 0 && lastDigit < 4) {
 		return ["st", "nd", "rd"][lastDigit - 1]
 	}
 


### PR DESCRIPTION
Hello,

Thank you for this gorgeous and simple calendar website. I am using it on a regular basis.
I've noticed that on 10th, 20th and 30th day of each month the top "today is" banner is showing "undefined" instead of "th" as ordinal suffix. See screenshot below:

![jac-error](https://user-images.githubusercontent.com/24464784/171003738-15055658-468a-4343-a3bc-587678fd5a42.png)

This is because in this case `lastDigit` is 0, and we are trying to get `[lastDigit - 1]` index from the array:

```ts
function ordinalSuffix(n: number): string {
  // This only works for numbers under 100, which is all we need.
  const lastDigit = n % 10

  if (n != 11 && n != 12 && n != 13 && lastDigit < 4) {
    return ["st", "nd", "rd"][lastDigit - 1]
  }

  return "th"
}
```

I propose simple fix by adding another check to the if.

Thank you,
Cheers

ympek
